### PR TITLE
Add firebase/php-jwt v6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "silverstripe/framework": "^5",
-    "level51/silverstripe-jwt-utils": "^0.2"
+    "level51/silverstripe-jwt-utils": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -3,6 +3,7 @@
 namespace FullscreenInteractive\Restful\Controllers;
 
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Level51\JWTUtils\JWTUtils;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPResponse;
@@ -228,8 +229,11 @@ class ApiController extends Controller
     {
         $token = JWT::decode(
             $this->getJwt(),
-            Config::inst()->get(JWTUtils::class, 'secret'),
-            ['HS256']);
+            new Key(
+                Config::inst()->get(JWTUtils::class, 'secret'),
+                'HS256'
+            )
+        );
 
         $member = Member::get()->byID($token->memberId);
 


### PR DESCRIPTION
Add compatibility for `"firebase/php-jwt": "^6.0"` which was introduced in the `1.0.0` tag of  `level51/silverstripe-jwt-utils`.  I've bumped up the version constraint accordingly too.