### PR TITLE
FIX adding support back in for Silverstripe 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "silverstripe/framework": "^5",
+    "silverstripe/framework": "^4 || ^5",
     "level51/silverstripe-jwt-utils": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Silverstripe 4 compat was removed with the previous release. Adding the composer requirement back in.